### PR TITLE
Windows crash on open fix from usbdevice.cpp

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,12 +13,14 @@ skip_tags: true
 
 platform:
   - x64
+  - x86
 
 configuration:
   - Release
+  - Debug
 
 matrix:
-  fast_finish: true
+  fast_finish: false
 
 clone_folder: C:\projects\openhantek
 
@@ -32,11 +34,14 @@ shallow_clone: true
 
 before_build:
   - if [%PLATFORM%] == [x64] set QT5=C:\Qt\5.8\msvc2015_64
-  - if [%PLATFORM%] == [x64] set VSARCH=x86
+  - if [%PLATFORM%] == [x64] set VSARCH=x64
   - if [%PLATFORM%] == [x64] set "CMAKE_GENERATOR_NAME=Visual Studio 14 2015 Win64"
   - if [%PLATFORM%] == [Win32] set QT5=C:\Qt\5.8\msvc2015
-  - if [%PLATFORM%] == [Win32] set VSARCH=x64
+  - if [%PLATFORM%] == [Win32] set VSARCH=x86
   - if [%PLATFORM%] == [Win32] set "CMAKE_GENERATOR_NAME=Visual Studio 14 2015"
+  - if [%PLATFORM%] == [x86] set QT5=C:\Qt\5.8\msvc2015
+  - if [%PLATFORM%] == [x86] set VSARCH=x86
+  - if [%PLATFORM%] == [x86] set "CMAKE_GENERATOR_NAME=Visual Studio 14 2015"
   - set Path=%QT5%\bin;%Path%
   - md build
   - cd build
@@ -46,12 +51,12 @@ before_build:
 build:
 
 build_script:
-  - cmake --build . --config Release --target package
+  - cmake --build . --config %configuration% --target package
 
 artifacts:
 
   - path: build\openhantek\$(configuration)
-    name: OpenHantek_jt-$(platform)-b$(APPVEYOR_BUILD_NUMBER)
+    name: OpenHantek_jt-$(platform)-$(configuration)-b$(APPVEYOR_BUILD_NUMBER)
     type: zip
 
   - path: build\packages\*.exe
@@ -60,8 +65,8 @@ artifacts:
 # User "ci-openhantek". Uses a appveyor encrypted github access token for that user.
 deploy:
   - provider: GitHub
-    artifact: OpenHantek_jt-$(platform)-b$(APPVEYOR_BUILD_NUMBER)
-    release: OpenHantek_jt-$(platform)-b$(APPVEYOR_BUILD_NUMBER)
+    artifact: OpenHantek_jt-$(platform)-$(configuration)-b$(APPVEYOR_BUILD_NUMBER)
+    release: OpenHantek_jt-b$(APPVEYOR_BUILD_NUMBER)
     description: 'OpenHantek Windows Build (ZIP)'    
     draft: false
     prerelease: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ build_script:
 artifacts:
 
   - path: build\openhantek\$(configuration)
-    name: OpenHantek_jt-$(platform)-$(APPVEYOR_REPO_COMMIT_TIMESTAMP).zip
+    name: OpenHantek_jt-$(platform)-b$(APPVEYOR_BUILD_NUMBER)
     type: zip
 
   - path: build\packages\*.exe
@@ -47,8 +47,8 @@ artifacts:
 # User "ci-openhantek". Uses a appveyor encrypted github access token for that user.
 deploy:
   - provider: GitHub
-    artifact: OpenHantek_jt-$(platform)-$(APPVEYOR_REPO_COMMIT_TIMESTAMP).zip
-    release: OpenHantek_jt-$(platform)-$(APPVEYOR_REPO_COMMIT_TIMESTAMP)
+    artifact: OpenHantek_jt-$(platform)-b$(APPVEYOR_BUILD_NUMBER)
+    release: OpenHantek_jt-$(platform)-b$(APPVEYOR_BUILD_NUMBER)
     description: 'OpenHantek Windows Build (ZIP)'    
     draft: false
     prerelease: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,16 @@
+# branches to build
+branches:
+  # whitelist
+  only:
+    - master
+ 
+  # blacklist
+  except:
+    - gh-pages
+
+# Do not build on tags (GitHub and BitBucket)
+skip_tags: true
+
 platform:
   - x64
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ build_script:
 artifacts:
 
   - path: build\openhantek\$(configuration)
-    name: zipped
+    name: OpenHantek_jt-$(platform)-$(APPVEYOR_REPO_COMMIT_TIMESTAMP).zip
     type: zip
 
   - path: build\packages\*.exe
@@ -47,14 +47,14 @@ artifacts:
 # User "ci-openhantek". Uses a appveyor encrypted github access token for that user.
 deploy:
   - provider: GitHub
-    artifact: zipped
-    release: openhantek-$(platform)-$(APPVEYOR_BUILD_NUMBER)
-    description: 'OpenHantek Windows Build'    
+    artifact: OpenHantek_jt-$(platform)-$(APPVEYOR_REPO_COMMIT_TIMESTAMP).zip
+    release: OpenHantek_jt-$(platform)-$(APPVEYOR_REPO_COMMIT_TIMESTAMP)
+    description: 'OpenHantek Windows Build (ZIP)'    
     draft: false
     prerelease: false
     force_update: true
     auth_token:
-      secure: o0pVKA7i8FmUbuK7uB0jpmrqruptxHCgd0PCHdz8uLW2HQ6DOn9xiO6UTo6f+eD+
+      secure: p5VWPfJhLhTNBBjEGnJaSbbhtFSjlWRZRABrrXbuPeo62x8iN1YpU8jah4hnSYlg
     on:
       branch: master                # release from master branch only
 #      appveyor_repo_tag: true       # deploy on tag push only

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,17 +37,24 @@ build_script:
 
 artifacts:
 
+  - path: build\openhantek\$(configuration)
+    name: zipped
+    type: zip
+
   - path: build\packages\*.exe
+    name: installer
 
 # User "ci-openhantek". Uses a appveyor encrypted github access token for that user.
 deploy:
   - provider: GitHub
-    artifact: /.*\.exe/
+    artifact: zipped
+    release: openhantek-$(platform)-$(APPVEYOR_BUILD_NUMBER)
+    description: 'OpenHantek Windows Build'    
     draft: false
     prerelease: false
     force_update: true
     auth_token:
-      secure: b48a79595d7ff052c542f01188bffd1ff4c32f77
+      secure: o0pVKA7i8FmUbuK7uB0jpmrqruptxHCgd0PCHdz8uLW2HQ6DOn9xiO6UTo6f+eD+
     on:
       branch: master                # release from master branch only
 #      appveyor_repo_tag: true       # deploy on tag push only

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,19 +35,25 @@ build:
 build_script:
   - cmake --build . --config Release --target package
 
+artifacts:
+
+  - path: build\packages\*.exe
+
 # User "ci-openhantek". Uses a appveyor encrypted github access token for that user.
 deploy:
   - provider: GitHub
-    artifact: /packages\\*\.exe/
+    artifact: /.*\.exe/
     draft: false
     prerelease: false
     force_update: true
     auth_token:
-      secure: KD4fRkMn+nap8Uw/8SDyAgqYREMPYkF+AOdl6e130Ha95lEAyCyLsKuIfFWsLy4c
+      secure: b48a79595d7ff052c542f01188bffd1ff4c32f77
     on:
       branch: master                # release from master branch only
-      appveyor_repo_tag: true       # deploy on tag push only
+#      appveyor_repo_tag: true       # deploy on tag push only
 
-notifications:
-  - provider: Email
-    on_build_status_changed: true
+#notifications:
+#  - provider: Email
+#    to:
+#      - user1@email.com
+#    on_build_status_changed: true

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ OpenHantek is a free software for Hantek and compatible (Voltcraft/Darkwire/Prot
   This allows a minimum window size of 640*480 for old workstation computers.
 
 ## Install prebuilt binary
-Navigate to the [Releases](https://github.com/OpenHantek/openhantek/releases) page 
+Navigate to the [Releases](releases) page 
 
 ## Building OpenHantek from source
 You need the following software, to build OpenHantek from source:

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ OpenHantek is a free software for Hantek and compatible (Voltcraft/Darkwire/Prot
   This allows a minimum window size of 640*480 for old workstation computers.
 
 ## Install prebuilt binary
-Navigate to the [Releases](releases) page 
+Navigate to the [Releases](https://github.com/thielj/openhantek/releases) page 
 
 ## Building OpenHantek from source
 You need the following software, to build OpenHantek from source:


### PR DESCRIPTION

This fixes an issue where in windows when DevicesListModel::updateDeviceList() (openhantek/src/selectdevice/deviceslistmodel.cpp: 76) calls  USBDevice::disconnectFromDevice(), it unrefs the libusb_device pointer named device, which destructs the underlying object.
*nix/OSX must hold onto another reference either inside the libusb library or the disconnect is not completely destructing the library properly so a reference is held inside libusb.  The only place the libusb_device pointer named device is inititialized is in the constructor.  Initialization either needs to happen in a connect, as well as properly setting the device to nullptr on disconnect, or my fix which works for windows is to simply unref the device object in the destructor, and set the pointer to nullptr.  I don't have a *nix box to test this.